### PR TITLE
remove deprecated types @types/mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,8 @@
     "": {
       "name": "diffusion-chain",
       "version": "1.0.5",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "@types/mkdirp": "^2.0.0",
         "@types/node": "^20.4.0",
         "mkdirp": "^3.0.1",
         "ts-node": "^10.9.1",
@@ -68,15 +67,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
-    },
-    "node_modules/@types/mkdirp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-2.0.0.tgz",
-      "integrity": "sha512-c/iUqMymAlxLAyIK3u5SzrwkrkyOdv1XDc91T+b5FsY7Jr6ERhUD19jJHOhPW4GD6tmN6mFEorfSdks525pwdQ==",
-      "deprecated": "This is a stub types definition. mkdirp provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "mkdirp": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "repository": "https://github.com/zombieyang/diffusion-chain",
   "dependencies": {
-    "@types/mkdirp": "^2.0.0",
     "@types/node": "^20.4.0",
     "mkdirp": "^3.0.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
deprecated message: 
"deprecated": "This is a stub types definition. mkdirp provides its own type definitions, so you do not need this installed.",