### PR TITLE
generate readable comfy error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "stable diffusion"
   ],
   "scripts": {
-    "test-sd": "cd test && ts-node test-server.ts",
-    "test-comfy": "cd test && ts-node test-comfy.ts",
+    "test-sd": "cd test && ts-node -O \"{\\\"module\\\":\\\"commonjs\\\",\\\"target\\\":\\\"es2022\\\"}\" test-server.ts",
+    "test-comfy": "cd test && ts-node -O \"{\\\"module\\\":\\\"commonjs\\\",\\\"target\\\":\\\"es2022\\\"}\" test-comfy.ts",
     "build": "tsc -p tsconfig.json"
   },
   "author": "zombieyang",

--- a/src/backends/comfyui-api.ts
+++ b/src/backends/comfyui-api.ts
@@ -14,6 +14,22 @@ export interface ComfyPrompt {
         [id: number]: ComfyPromptNode
     }
 }
+interface ComfyError {
+    type: string
+    message: string
+    details: string
+    extra_info: any
+}
+
+interface NodeError {
+    errors: ComfyError[]
+    dependent_outputs: string[]
+    class_type: string
+}
+export interface ComfyResult {
+    error?: ComfyError
+    node_errors?: { [key: string]: NodeError }
+}
 
 export class ComfyApi {
     public static async prompt(comfyui: ComfyServer, payload: ComfyPrompt) {


### PR DESCRIPTION
If generation fails, parse the Comfy result to produce a human-readable error.